### PR TITLE
Dse 996

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ libraryDependencies ++= Seq(
   Library.Specs2.matcherExtra,
   Library.Specs2.mock,
   Library.Specs2.core,
-  Library.HATDeX.hatClient,
+  Library.DataswiftModels.hat,
+  Library.DataswiftModels.hatPlay,
   Library.Test.scalacheck,
   Library.Test.scalatest,
   Library.Test.funsuite,
@@ -21,16 +22,14 @@ libraryDependencies ++= Seq(
   Library.Test.logging
 )
 
+publishMavenStyle := true
 publishTo := {
-  val prefix               = if (isSnapshot.value) "snapshots" else "releases"
-  val s3BucketFriendlyName = "HAT Library Artifacts"
-  val s3BucketName         = "library-artifacts-"
-  val s3DomainSuffix       = ".hubofallthings.com"
+  val prefix = if (isSnapshot.value) "snapshots" else "releases"
   Some(
-    s3resolver
-      .value(List(s3BucketName, prefix).mkString(""), s3(s3BucketName + prefix + s3DomainSuffix)) withMavenPatterns
+    "Models" + prefix at "s3://library-artifacts-" + prefix + ".hubofallthings.com"
   )
 }
+
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ publishMavenStyle := true
 publishTo := {
   val prefix = if (isSnapshot.value) "snapshots" else "releases"
   Some(
-    "Models" + prefix at "s3://library-artifacts-" + prefix + ".hubofallthings.com"
+    s"Models$prefix" at s"s3://library-artifacts-$prefix.hubofallthings.com"
   )
 }
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -19,7 +19,7 @@ object BasicSettings extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
       organization := "org.hatdex",
-      version := "2.6.12",
+      version := "3.0.0",
       resolvers ++= Dependencies.resolvers,
       scalaVersion := Dependencies.Versions.scalaVersion,
       crossScalaVersions := Dependencies.Versions.crossScala,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,9 +39,15 @@ object Dependencies {
       val mock            = "org.specs2" %% "specs2-mock"          % version
     }
 
-    object HATDeX {
-      private val version = "2.6.18"
-      val hatClient       = "org.hatdex" %% "hat-client-scala-play" % version
+    object DataswiftModels {
+
+      private val version =
+        "1.0.0-SNAPSHOT"
+      val hat     = "io.dataswift.models" %% "hat"      % version
+      val hatPlay = "io.dataswift.models" %% "hat-play" % version
+      val dex     = "io.dataswift.models" %% "dex"      % version
+      val dexPlay = "io.dataswift.models" %% "dex-play" % version
+
     }
 
     object Test {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,7 @@ object Dependencies {
     object DataswiftModels {
 
       private val version =
-        "1.0.0-SNAPSHOT"
+        "1.0.0"
       val hat     = "io.dataswift.models" %% "hat"      % version
       val hatPlay = "io.dataswift.models" %% "hat-play" % version
       val dex     = "io.dataswift.models" %% "dex"      % version

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,8 +9,6 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
 
 // Code Quality
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
-//addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
-//addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.1")
 
 // web plugins
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.3")
@@ -18,9 +16,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.12")
 
-// S3 based SBT resolver
-
-resolvers += "FrugalMechanic Snapshots" at "s3://maven.frugalmechanic.com/snapshots"
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")
 
 resolvers += "HAT Library Artifacts Snapshots" at "https://s3-eu-west-1.amazonaws.com/library-artifacts-snapshots.hubofallthings.com"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,8 +19,9 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.12")
 
 // S3 based SBT resolver
-resolvers += Resolver.jcenterRepo
-addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.19.0")
+
+resolvers += "FrugalMechanic Snapshots" at "s3://maven.frugalmechanic.com/snapshots"
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")
 
 resolvers += "HAT Library Artifacts Snapshots" at "https://s3-eu-west-1.amazonaws.com/library-artifacts-snapshots.hubofallthings.com"
 resolvers += "HAT Library Artifacts Releases" at "https://s3-eu-west-1.amazonaws.com/library-artifacts-releases.hubofallthings.com"

--- a/src/it/scala/org/hatdex/dex/apiV3/services/DexApplicationsItTest.scala
+++ b/src/it/scala/org/hatdex/dex/apiV3/services/DexApplicationsItTest.scala
@@ -1,6 +1,6 @@
 package org.hatdex.dex.apiV3.services
 import org.hatdex.dex.apiV2.services.Errors.DetailsNotFoundException
-import org.hatdex.hat.api.models.applications.ApplicationKind
+import io.dataswift.models.hat.applications.ApplicationKind
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/src/main/scala/org/hatdex/dex/api/json/DexJsonFormats.scala
+++ b/src/main/scala/org/hatdex/dex/api/json/DexJsonFormats.scala
@@ -9,13 +9,11 @@
 
 package org.hatdex.dex.api.json
 
-import org.hatdex.hat.api.json.HatJsonFormats
+import io.dataswift.models.hat.json.HatJsonFormats
 import org.hatdex.dex.api.models._
 import play.api.libs.json._
 
 trait DexJsonFormats extends HatJsonFormats {
-  import play.api.libs.json.JodaWrites._
-  import play.api.libs.json.JodaReads._
 
   implicit val offerHatFormat: OFormat[OfferHat]                       = Json.format[OfferHat]
   implicit val offerclaimFormat: OFormat[OfferClaim]                   = Json.format[OfferClaim]

--- a/src/main/scala/org/hatdex/dex/api/services/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/api/services/DexStats.scala
@@ -9,7 +9,7 @@
 
 package org.hatdex.dex.api.services
 
-import org.hatdex.hat.api.models.DataStats
+import io.dataswift.models.hat.DataStats
 import play.api.Logger
 import play.api.http.Status._
 import play.api.libs.json.Json
@@ -19,7 +19,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 trait DexStats {
 
-  import org.hatdex.hat.api.json.DataStatsFormat.dataStatsFormat
+  import io.dataswift.models.hat.json.DataStatsFormat.dataStatsFormat
 
   val logger: Logger
   val ws: WSClient

--- a/src/main/scala/org/hatdex/dex/apiV2/json/DexJsonFormats.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/json/DexJsonFormats.scala
@@ -9,7 +9,7 @@
 
 package org.hatdex.dex.apiV2.json
 
-import org.hatdex.hat.api.json.{ DataDebitFormats, RichDataJsonFormats }
+import io.dataswift.models.hat.json.{ DataDebitFormats, RichDataJsonFormats }
 import org.hatdex.dex.apiV2.models._
 import play.api.libs.functional.syntax._
 import play.api.libs.json._

--- a/src/main/scala/org/hatdex/dex/apiV2/models/Offer.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/models/Offer.scala
@@ -2,7 +2,7 @@ package org.hatdex.dex.apiV2.models
 
 import java.util.UUID
 
-import org.hatdex.hat.api.models.EndpointDataBundle
+import io.dataswift.models.hat.EndpointDataBundle
 import org.joda.time.{ DateTime, Duration }
 
 case class Offer(

--- a/src/main/scala/org/hatdex/dex/apiV2/services/DexApplications.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/services/DexApplications.scala
@@ -17,7 +17,7 @@ import org.hatdex.dex.apiV2.services.Errors.{
   ForbiddenActionException,
   UnauthorizedActionException
 }
-import org.hatdex.hat.api.models.applications.{ Application, ApplicationDeveloper, ApplicationHistory }
+import io.dataswift.models.hat.applications.{ Application, ApplicationDeveloper, ApplicationHistory }
 import play.api.Logger
 import play.api.http.Status._
 import play.api.libs.json.{ Format, JsError, JsSuccess, Json }
@@ -34,11 +34,11 @@ trait DexApplications {
   protected val apiVersion: String
 
   implicit protected val applicationFormat: Format[Application] =
-    org.hatdex.hat.api.json.ApplicationJsonProtocol.applicationFormat
+    io.dataswift.models.hat.json.ApplicationJsonProtocol.applicationFormat
   implicit protected val applicationHistoryFormat: Format[ApplicationHistory] =
-    org.hatdex.hat.api.json.ApplicationJsonProtocol.applicationHistoryFormat
+    io.dataswift.models.hat.json.ApplicationJsonProtocol.applicationHistoryFormat
   implicit protected val developerFormat: Format[ApplicationDeveloper] =
-    org.hatdex.hat.api.json.ApplicationJsonProtocol.applicationDeveloperFormat
+    io.dataswift.models.hat.json.ApplicationJsonProtocol.applicationDeveloperFormat
 
   def applications(includeUnpublished: Boolean = false)(implicit ec: ExecutionContext): Future[Seq[Application]] = {
     val request: WSRequest = ws

--- a/src/main/scala/org/hatdex/dex/apiV2/services/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/services/DexStats.scala
@@ -12,7 +12,7 @@ package org.hatdex.dex.apiV2.services
 import org.hatdex.dex.apiV2.json.DexJsonFormats
 import org.hatdex.dex.apiV2.models.NamespaceStructure
 import org.hatdex.dex.apiV2.services.Errors.{ ApiException, DataFormatException }
-import org.hatdex.hat.api.models.DataStats
+import io.dataswift.models.hat.DataStats
 import play.api.Logger
 import play.api.http.Status._
 import play.api.libs.json.Json
@@ -29,7 +29,9 @@ trait DexStats {
   protected val dexAddress: String
   protected val apiVersion: String
 
-  implicit protected val dataStatsFormat: Format[DataStats]                   = org.hatdex.hat.api.json.DataStatsFormat.dataStatsFormat
+  implicit protected val dataStatsFormat: Format[DataStats]                   =
+    io.dataswift.models.hat.json.DataStatsFormat.dataStatsFormat
+
   implicit protected val namespaceStructureFormat: Format[NamespaceStructure] = DexJsonFormats.namespaceStructureFormat
 
   def postStats(

--- a/src/main/scala/org/hatdex/dex/apiV3/json/DexJsonFormats.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/json/DexJsonFormats.scala
@@ -9,7 +9,7 @@
 
 package org.hatdex.dex.apiV3.json
 
-import org.hatdex.hat.api.json.{ DataDebitFormats, RichDataJsonFormats }
+import io.dataswift.models.hat.json.{ DataDebitFormats, RichDataJsonFormats }
 import org.hatdex.dex.apiV3.models._
 import play.api.libs.functional.syntax._
 import play.api.libs.json._

--- a/src/main/scala/org/hatdex/dex/apiV3/models/Offer.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/models/Offer.scala
@@ -2,7 +2,7 @@ package org.hatdex.dex.apiV3.models
 
 import java.util.UUID
 
-import org.hatdex.hat.api.models.EndpointDataBundle
+import io.dataswift.models.hat.EndpointDataBundle
 import org.joda.time.{ DateTime, Duration }
 
 case class Offer(

--- a/src/main/scala/org/hatdex/dex/apiV3/services/DexApplications.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/services/DexApplications.scala
@@ -17,7 +17,7 @@ import org.hatdex.dex.apiV2.services.Errors.{
   ForbiddenActionException,
   UnauthorizedActionException
 }
-import org.hatdex.hat.api.models.applications.{
+import io.dataswift.models.hat.applications.{
   Application,
   ApplicationDeveloper,
   ApplicationHistory,
@@ -33,7 +33,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 trait DexApplications {
 
-  import org.hatdex.hat.api.json.ApplicationJsonProtocol._
+  import io.dataswift.models.hat.json.ApplicationJsonProtocol._
 
   protected val logger: Logger
   protected val ws: WSClient

--- a/src/main/scala/org/hatdex/dex/apiV3/services/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/services/DexStats.scala
@@ -12,7 +12,7 @@ package org.hatdex.dex.apiV3.services
 import org.hatdex.dex.apiV3.json.DexJsonFormats
 import org.hatdex.dex.apiV3.models.NamespaceStructure
 import org.hatdex.dex.apiV3.services.Errors.{ ApiException, DataFormatException }
-import org.hatdex.hat.api.models.DataStats
+import io.dataswift.models.hat.DataStats
 import play.api.Logger
 import play.api.http.Status._
 import play.api.libs.json.Json
@@ -29,7 +29,7 @@ trait DexStats {
   protected val dexAddress: String
   protected val apiVersion: String
 
-  implicit protected val dataStatsFormat: Format[DataStats]                   = org.hatdex.hat.api.json.DataStatsFormat.dataStatsFormat
+  implicit protected val dataStatsFormat: Format[DataStats]                   = io.dataswift.models.hat.json.DataStatsFormat.dataStatsFormat
   implicit protected val namespaceStructureFormat: Format[NamespaceStructure] = DexJsonFormats.namespaceStructureFormat
 
   def postStats(


### PR DESCRIPTION
## Description
* Remove dependency on HAT client
* Use latest Models for hat models

## Why 
* Remove the dependency on HAT client (specific to play) when only the models are required

## AC
Extract the known models and types from the HAT client that are used in DEX and DevPortal and place them in  

## Source
https://dswift.atlassian.net/jira/software/projects/DSE/boards/5?assignee=5eb9575dc5c6230baa5c04bb&selectedIssue=DSE-996

## Blocking
* https://github.com/dataswift/hatters/pull/174


## Type
- [ ] Bug Fix
- [ ] Feature Addition 
- [X] Refactor
- [ ] HotFix

## Checklist
- [X] tested locally
- [X] added new dependencies
- [ ] updated the docs
- [ ] added a test
