### PR TITLE
get rid of service package as it is redundant

### DIFF
--- a/src/it/scala/org/hatdex/dex/apiV3/DexApplicationsItTest.scala
+++ b/src/it/scala/org/hatdex/dex/apiV3/DexApplicationsItTest.scala
@@ -1,7 +1,7 @@
-package org.hatdex.dex.apiV3.services
+package org.hatdex.dex.apiV3
+
 import org.hatdex.dex.apiV2.Errors.DetailsNotFoundException
 import io.dataswift.models.hat.applications.ApplicationKind
-import org.hatdex.dex.apiV3.DexClient
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/src/it/scala/org/hatdex/dex/apiV3/services/DexApplicationsItTest.scala
+++ b/src/it/scala/org/hatdex/dex/apiV3/services/DexApplicationsItTest.scala
@@ -1,6 +1,7 @@
 package org.hatdex.dex.apiV3.services
-import org.hatdex.dex.apiV2.services.Errors.DetailsNotFoundException
+import org.hatdex.dex.apiV2.Errors.DetailsNotFoundException
 import io.dataswift.models.hat.applications.ApplicationKind
+import org.hatdex.dex.apiV3.DexClient
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/src/main/scala/org/hatdex/dex/api/DexClient.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexClient.scala
@@ -7,29 +7,24 @@
  *
  */
 
-package org.hatdex.dex.apiV2.services
+package org.hatdex.dex.api
 
 import javax.inject.Inject
-
-import org.hatdex.dex.api.services.{ DexDataPlugs, DexNotices }
 import play.api.Logger
 import play.api.libs.ws.WSClient
 
 class DexClient(
     val ws: WSClient,
     val dexAddress: String,
-    override val schema: String,
-    override val apiVersion: String)
+    override val schema: String)
     extends DexOffers
     with DexNotices
     with DexDataPlugs
-    with DexStats
-    with DexUsers
-    with DexApplications {
+    with DexStats {
 
   @Inject def this(
       ws: WSClient,
-      dexAddress: String) = this(ws, dexAddress, "https://", "v1.1")
+      dexAddress: String) = this(ws, dexAddress, "https://")
 
   val logger: Logger = play.api.Logger(this.getClass)
 }

--- a/src/main/scala/org/hatdex/dex/api/DexClient.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexClient.scala
@@ -10,6 +10,7 @@
 package org.hatdex.dex.api
 
 import javax.inject.Inject
+
 import play.api.Logger
 import play.api.libs.ws.WSClient
 

--- a/src/main/scala/org/hatdex/dex/api/DexDataPlugs.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexDataPlugs.scala
@@ -1,21 +1,15 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
+package org.hatdex.dex.api
 
-package org.hatdex.dex.api.services
+import play.api.http.Status.OK
+import play.api.libs.ws.WSResponse
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import play.api.libs.ws.WSClient
+import play.api.libs.ws.WSRequest
 import java.util.UUID
 
-import scala.concurrent.{ ExecutionContext, Future }
-
 import play.api.Logger
-import play.api.http.Status._
-import play.api.libs.ws._
 
 trait DexDataPlugs {
   val logger: Logger

--- a/src/main/scala/org/hatdex/dex/api/DexDataPlugs.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexDataPlugs.scala
@@ -1,15 +1,12 @@
 package org.hatdex.dex.api
 
-import play.api.http.Status.OK
-import play.api.libs.ws.WSResponse
-
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
-import play.api.libs.ws.WSClient
-import play.api.libs.ws.WSRequest
 import java.util.UUID
 
+import scala.concurrent.{ExecutionContext, Future}
+
 import play.api.Logger
+import play.api.http.Status.OK
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexDataPlugs {
   val logger: Logger

--- a/src/main/scala/org/hatdex/dex/api/DexNotices.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexNotices.scala
@@ -1,22 +1,17 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
+package org.hatdex.dex.api
 
-package org.hatdex.dex.api.services
+import play.api.libs.ws.WSClient
+import play.api.libs.ws.WSRequest
+import play.api.http.Status.OK
 
-import scala.concurrent.{ ExecutionContext, Future }
-
-import io.dataswift.models.dex.Notice
+import scala.concurrent.ExecutionContext
 import io.dataswift.models.dex.json.DexJsonFormats
-import play.api.Logger
-import play.api.http.Status._
+import play.api.libs.ws.WSResponse
+import io.dataswift.models.dex.Notice
+
+import scala.concurrent.Future
 import play.api.libs.json.Json
-import play.api.libs.ws._
+import play.api.Logger
 
 trait DexNotices {
   val logger: Logger

--- a/src/main/scala/org/hatdex/dex/api/DexNotices.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexNotices.scala
@@ -1,17 +1,13 @@
 package org.hatdex.dex.api
 
-import play.api.libs.ws.WSClient
-import play.api.libs.ws.WSRequest
-import play.api.http.Status.OK
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.ExecutionContext
-import io.dataswift.models.dex.json.DexJsonFormats
-import play.api.libs.ws.WSResponse
 import io.dataswift.models.dex.Notice
-
-import scala.concurrent.Future
-import play.api.libs.json.Json
+import io.dataswift.models.dex.json.DexJsonFormats
 import play.api.Logger
+import play.api.http.Status.OK
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexNotices {
   val logger: Logger

--- a/src/main/scala/org/hatdex/dex/api/DexOffers.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexOffers.scala
@@ -1,22 +1,16 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
-
-package org.hatdex.dex.api.services
-
-import java.util.UUID
-
-import scala.concurrent.{ ExecutionContext, Future }
+package org.hatdex.dex.api
 
 import io.dataswift.models.dex.OfferClaimsInfo
+import play.api.libs.ws.WSRequest
+import play.api.libs.ws.WSResponse
 import play.api.Logger
-import play.api.http.Status._
-import play.api.libs.ws._
+import java.util.UUID
+
+import scala.concurrent.Future
+import play.api.libs.ws.WSClient
+import play.api.http.Status.OK
+
+import scala.concurrent.ExecutionContext
 
 trait DexOffers {
   val logger: Logger

--- a/src/main/scala/org/hatdex/dex/api/DexOffers.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexOffers.scala
@@ -1,16 +1,13 @@
 package org.hatdex.dex.api
 
-import io.dataswift.models.dex.OfferClaimsInfo
-import play.api.libs.ws.WSRequest
-import play.api.libs.ws.WSResponse
-import play.api.Logger
 import java.util.UUID
 
-import scala.concurrent.Future
-import play.api.libs.ws.WSClient
-import play.api.http.Status.OK
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.ExecutionContext
+import io.dataswift.models.dex.OfferClaimsInfo
+import play.api.Logger
+import play.api.http.Status.OK
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexOffers {
   val logger: Logger

--- a/src/main/scala/org/hatdex/dex/api/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexStats.scala
@@ -1,15 +1,12 @@
 package org.hatdex.dex.api
 
-import scala.concurrent.ExecutionContext
-import play.api.libs.ws.WSResponse
-import io.dataswift.models.hat.DataStats
-import play.api.libs.json.Json
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.Future
-import play.api.http.Status.OK
-import play.api.libs.ws.WSClient
-import play.api.libs.ws.WSRequest
+import io.dataswift.models.hat.DataStats
 import play.api.Logger
+import play.api.http.Status.OK
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexStats {
 

--- a/src/main/scala/org/hatdex/dex/api/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexStats.scala
@@ -1,21 +1,15 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
+package org.hatdex.dex.api
 
-package org.hatdex.dex.api.services
-
-import scala.concurrent.{ ExecutionContext, Future }
-
+import scala.concurrent.ExecutionContext
+import play.api.libs.ws.WSResponse
 import io.dataswift.models.hat.DataStats
-import play.api.Logger
-import play.api.http.Status._
 import play.api.libs.json.Json
-import play.api.libs.ws._
+
+import scala.concurrent.Future
+import play.api.http.Status.OK
+import play.api.libs.ws.WSClient
+import play.api.libs.ws.WSRequest
+import play.api.Logger
 
 trait DexStats {
 

--- a/src/main/scala/org/hatdex/dex/apiV2/DexApplications.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexApplications.scala
@@ -1,26 +1,14 @@
 package org.hatdex.dex.apiV2
 
-import play.api.http.Status.NOT_FOUND
-import play.api.libs.ws.WSClient
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.Future
-import play.api.libs.json.JsSuccess
-import play.api.http.Status.FORBIDDEN
-import io.dataswift.models.hat.applications.ApplicationHistory
-import io.dataswift.models.hat.applications.ApplicationDeveloper
-import play.api.libs.ws.WSRequest
-import play.api.libs.ws.WSResponse
-import play.api.http.Status.CREATED
-import play.api.http.Status.UNAUTHORIZED
-import play.api.libs.json.Json
-import play.api.Logger
 import akka.Done
-import io.dataswift.models.hat.applications.Application
-
-import scala.concurrent.ExecutionContext
-import play.api.http.Status.OK
-import play.api.libs.json.Format
-import play.api.libs.json.JsError
+import io.dataswift.models.hat.applications.{Application, ApplicationDeveloper, ApplicationHistory}
+import org.hatdex.dex.apiV2.Errors._
+import play.api.Logger
+import play.api.http.Status.{CREATED, FORBIDDEN, NOT_FOUND, OK, UNAUTHORIZED}
+import play.api.libs.json.{Format, JsError, JsSuccess, Json}
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexApplications {
 

--- a/src/main/scala/org/hatdex/dex/apiV2/DexApplications.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexApplications.scala
@@ -1,29 +1,26 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
+package org.hatdex.dex.apiV2
 
-package org.hatdex.dex.apiV2.services
+import play.api.http.Status.NOT_FOUND
+import play.api.libs.ws.WSClient
 
-import scala.concurrent.{ ExecutionContext, Future }
-
-import akka.Done
-import io.dataswift.models.hat.applications.{ Application, ApplicationDeveloper, ApplicationHistory }
-import org.hatdex.dex.apiV2.services.Errors.{
-  ApiException,
-  DataFormatException,
-  DetailsNotFoundException,
-  ForbiddenActionException,
-  UnauthorizedActionException
-}
+import scala.concurrent.Future
+import play.api.libs.json.JsSuccess
+import play.api.http.Status.FORBIDDEN
+import io.dataswift.models.hat.applications.ApplicationHistory
+import io.dataswift.models.hat.applications.ApplicationDeveloper
+import play.api.libs.ws.WSRequest
+import play.api.libs.ws.WSResponse
+import play.api.http.Status.CREATED
+import play.api.http.Status.UNAUTHORIZED
+import play.api.libs.json.Json
 import play.api.Logger
-import play.api.http.Status._
-import play.api.libs.json.{ Format, JsError, JsSuccess, Json }
-import play.api.libs.ws._
+import akka.Done
+import io.dataswift.models.hat.applications.Application
+
+import scala.concurrent.ExecutionContext
+import play.api.http.Status.OK
+import play.api.libs.json.Format
+import play.api.libs.json.JsError
 
 trait DexApplications {
 

--- a/src/main/scala/org/hatdex/dex/apiV2/DexClient.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexClient.scala
@@ -7,25 +7,29 @@
  *
  */
 
-package org.hatdex.dex.api.services
+package org.hatdex.dex.apiV2
 
 import javax.inject.Inject
-
+import org.hatdex.dex.api.DexDataPlugs
+import org.hatdex.dex.api.DexNotices
 import play.api.Logger
 import play.api.libs.ws.WSClient
 
 class DexClient(
     val ws: WSClient,
     val dexAddress: String,
-    override val schema: String)
+    override val schema: String,
+    override val apiVersion: String)
     extends DexOffers
     with DexNotices
     with DexDataPlugs
-    with DexStats {
+    with DexStats
+    with DexUsers
+    with DexApplications {
 
   @Inject def this(
       ws: WSClient,
-      dexAddress: String) = this(ws, dexAddress, "https://")
+      dexAddress: String) = this(ws, dexAddress, "https://", "v1.1")
 
   val logger: Logger = play.api.Logger(this.getClass)
 }

--- a/src/main/scala/org/hatdex/dex/apiV2/DexClient.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexClient.scala
@@ -10,8 +10,8 @@
 package org.hatdex.dex.apiV2
 
 import javax.inject.Inject
-import org.hatdex.dex.api.DexDataPlugs
-import org.hatdex.dex.api.DexNotices
+
+import org.hatdex.dex.api.{DexDataPlugs, DexNotices}
 import play.api.Logger
 import play.api.libs.ws.WSClient
 

--- a/src/main/scala/org/hatdex/dex/apiV2/DexOffers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexOffers.scala
@@ -1,22 +1,24 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
+package org.hatdex.dex.apiV2
 
-package org.hatdex.dex.apiV2.services
-
-import scala.concurrent.{ ExecutionContext, Future }
-
-import io.dataswift.models.dex.{ Offer, OfferClaimSummary, OfferClaimsInfo, OfferRegistration }
-import org.hatdex.dex.apiV2.services.Errors._
-import play.api.Logger
-import play.api.http.Status._
+import play.api.http.Status.OK
+import play.api.http.Status.FORBIDDEN
 import play.api.libs.json.Json
-import play.api.libs.ws._
+import play.api.http.Status.CREATED
+import io.dataswift.models.dex.OfferClaimSummary
+import io.dataswift.models.dex.Offer
+import play.api.libs.ws.WSClient
+import io.dataswift.models.dex.OfferClaimsInfo
+import play.api.libs.ws.WSRequest
+import io.dataswift.models.dex.OfferRegistration
+
+import scala.concurrent.ExecutionContext
+import play.api.http.Status.BAD_REQUEST
+import play.api.libs.ws.WSResponse
+import play.api.http.Status.UNAUTHORIZED
+import play.api.http.Status.NOT_FOUND
+
+import scala.concurrent.Future
+import play.api.Logger
 
 trait DexOffers {
   protected val logger: Logger

--- a/src/main/scala/org/hatdex/dex/apiV2/DexOffers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexOffers.scala
@@ -1,24 +1,13 @@
 package org.hatdex.dex.apiV2
 
-import play.api.http.Status.OK
-import play.api.http.Status.FORBIDDEN
-import play.api.libs.json.Json
-import play.api.http.Status.CREATED
-import io.dataswift.models.dex.OfferClaimSummary
-import io.dataswift.models.dex.Offer
-import play.api.libs.ws.WSClient
-import io.dataswift.models.dex.OfferClaimsInfo
-import play.api.libs.ws.WSRequest
-import io.dataswift.models.dex.OfferRegistration
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.ExecutionContext
-import play.api.http.Status.BAD_REQUEST
-import play.api.libs.ws.WSResponse
-import play.api.http.Status.UNAUTHORIZED
-import play.api.http.Status.NOT_FOUND
-
-import scala.concurrent.Future
+import io.dataswift.models.dex.{Offer, OfferClaimSummary, OfferClaimsInfo, OfferRegistration}
+import org.hatdex.dex.apiV2.Errors._
 import play.api.Logger
+import play.api.http.Status.{BAD_REQUEST, CREATED, FORBIDDEN, NOT_FOUND, OK, UNAUTHORIZED}
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexOffers {
   protected val logger: Logger

--- a/src/main/scala/org/hatdex/dex/apiV2/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexStats.scala
@@ -1,19 +1,15 @@
 package org.hatdex.dex.apiV2
 
-import play.api.libs.ws.WSResponse
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.Future
-import play.api.http.Status.OK
-import play.api.libs.json.Format
-import play.api.libs.ws.WSClient
-
-import scala.concurrent.ExecutionContext
-import io.dataswift.models.dex.json.DexJsonFormats
 import io.dataswift.models.dex.NamespaceStructure
+import io.dataswift.models.dex.json.DexJsonFormats
 import io.dataswift.models.hat.DataStats
+import org.hatdex.dex.apiV2.Errors._
 import play.api.Logger
-import play.api.libs.ws.WSRequest
-import play.api.libs.json.Json
+import play.api.http.Status.OK
+import play.api.libs.json.{Format, Json}
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexStats {
 

--- a/src/main/scala/org/hatdex/dex/apiV2/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexStats.scala
@@ -1,24 +1,19 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
+package org.hatdex.dex.apiV2
 
-package org.hatdex.dex.apiV3.services
+import play.api.libs.ws.WSResponse
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
+import play.api.http.Status.OK
+import play.api.libs.json.Format
+import play.api.libs.ws.WSClient
 
-import io.dataswift.models.dex.NamespaceStructure
+import scala.concurrent.ExecutionContext
 import io.dataswift.models.dex.json.DexJsonFormats
+import io.dataswift.models.dex.NamespaceStructure
 import io.dataswift.models.hat.DataStats
-import org.hatdex.dex.apiV3.services.Errors.{ ApiException, DataFormatException }
 import play.api.Logger
-import play.api.http.Status._
-import play.api.libs.json.{ Format, Json }
-import play.api.libs.ws._
+import play.api.libs.ws.WSRequest
+import play.api.libs.json.Json
 
 trait DexStats {
 
@@ -30,6 +25,7 @@ trait DexStats {
 
   implicit protected val dataStatsFormat: Format[DataStats] =
     io.dataswift.models.hat.json.DataStatsFormat.dataStatsFormat
+
   implicit protected val namespaceStructureFormat: Format[NamespaceStructure] = DexJsonFormats.namespaceStructureFormat
 
   def postStats(

--- a/src/main/scala/org/hatdex/dex/apiV2/DexUsers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexUsers.scala
@@ -1,22 +1,4 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
-
-package org.hatdex.dex.apiV2.services
-
-import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContext, Future }
-
-import akka.Done
-import play.api.Logger
-import play.api.http.Status._
-import play.api.libs.json.Json
-import play.api.libs.ws._
+package org.hatdex.dex.apiV2
 
 trait DexUsers {
 

--- a/src/main/scala/org/hatdex/dex/apiV2/DexUsers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexUsers.scala
@@ -1,5 +1,14 @@
 package org.hatdex.dex.apiV2
 
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Future }
+
+import akka.Done
+import play.api.Logger
+import play.api.http.Status._
+import play.api.libs.json.Json
+import play.api.libs.ws._
+
 trait DexUsers {
 
   protected val logger: Logger

--- a/src/main/scala/org/hatdex/dex/apiV2/Errors.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/Errors.scala
@@ -1,4 +1,4 @@
-package org.hatdex.dex.apiV2.services
+package org.hatdex.dex.apiV2
 
 object Errors {
   class ApiException(

--- a/src/main/scala/org/hatdex/dex/apiV3/DexApplications.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexApplications.scala
@@ -1,35 +1,32 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
+package org.hatdex.dex.apiV3
 
-package org.hatdex.dex.apiV3.services
+import play.api.libs.ws.WSClient
+import play.api.http.Status.NOT_FOUND
+import io.dataswift.models.hat.applications.ApplicationDeveloper
+import org.hatdex.dex.apiV2.Errors.ForbiddenActionException
+import play.api.libs.json.JsSuccess
+import io.dataswift.models.hat.applications.ApplicationKind
+import org.hatdex.dex.apiV2.Errors.ApiException
+import io.dataswift.models.hat.applications.PayloadWrapper
+import play.api.libs.ws.WSRequest
+import org.hatdex.dex.apiV2.Errors.DetailsNotFoundException
+import io.dataswift.models.hat.applications.ApplicationHistory
 
-import scala.concurrent.{ ExecutionContext, Future }
-
+import scala.concurrent.Future
+import play.api.libs.json.Json
+import play.api.libs.ws.WSResponse
 import akka.Done
-import io.dataswift.models.hat.applications.{
-  Application,
-  ApplicationDeveloper,
-  ApplicationHistory,
-  ApplicationKind,
-  PayloadWrapper
-}
-import org.hatdex.dex.apiV2.services.Errors.{
-  ApiException,
-  DataFormatException,
-  DetailsNotFoundException,
-  ForbiddenActionException,
-  UnauthorizedActionException
-}
 import play.api.Logger
-import play.api.http.Status._
-import play.api.libs.json.{ JsError, JsSuccess, Json }
-import play.api.libs.ws._
+import io.dataswift.models.hat.applications.Application
+
+import scala.concurrent.ExecutionContext
+import play.api.http.Status.OK
+import org.hatdex.dex.apiV2.Errors.UnauthorizedActionException
+import play.api.http.Status.CREATED
+import play.api.http.Status.UNAUTHORIZED
+import play.api.libs.json.JsError
+import org.hatdex.dex.apiV2.Errors.DataFormatException
+import play.api.http.Status.FORBIDDEN
 
 trait DexApplications {
 

--- a/src/main/scala/org/hatdex/dex/apiV3/DexApplications.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexApplications.scala
@@ -1,32 +1,14 @@
 package org.hatdex.dex.apiV3
 
-import play.api.libs.ws.WSClient
-import play.api.http.Status.NOT_FOUND
-import io.dataswift.models.hat.applications.ApplicationDeveloper
-import org.hatdex.dex.apiV2.Errors.ForbiddenActionException
-import play.api.libs.json.JsSuccess
-import io.dataswift.models.hat.applications.ApplicationKind
-import org.hatdex.dex.apiV2.Errors.ApiException
-import io.dataswift.models.hat.applications.PayloadWrapper
-import play.api.libs.ws.WSRequest
-import org.hatdex.dex.apiV2.Errors.DetailsNotFoundException
-import io.dataswift.models.hat.applications.ApplicationHistory
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.Future
-import play.api.libs.json.Json
-import play.api.libs.ws.WSResponse
 import akka.Done
+import io.dataswift.models.hat.applications.{Application, ApplicationDeveloper, ApplicationHistory, ApplicationKind, PayloadWrapper}
+import org.hatdex.dex.apiV2.Errors.{ApiException, DataFormatException, DetailsNotFoundException, ForbiddenActionException, UnauthorizedActionException}
 import play.api.Logger
-import io.dataswift.models.hat.applications.Application
-
-import scala.concurrent.ExecutionContext
-import play.api.http.Status.OK
-import org.hatdex.dex.apiV2.Errors.UnauthorizedActionException
-import play.api.http.Status.CREATED
-import play.api.http.Status.UNAUTHORIZED
-import play.api.libs.json.JsError
-import org.hatdex.dex.apiV2.Errors.DataFormatException
-import play.api.http.Status.FORBIDDEN
+import play.api.http.Status.{CREATED, FORBIDDEN, NOT_FOUND, OK, UNAUTHORIZED}
+import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexApplications {
 

--- a/src/main/scala/org/hatdex/dex/apiV3/DexClient.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexClient.scala
@@ -7,11 +7,11 @@
  *
  */
 
-package org.hatdex.dex.apiV3.services
+package org.hatdex.dex.apiV3
 
 import javax.inject.Inject
-
-import org.hatdex.dex.api.services.{ DexDataPlugs, DexNotices }
+import org.hatdex.dex.api.DexDataPlugs
+import org.hatdex.dex.api.DexNotices
 import play.api.Logger
 import play.api.libs.ws.WSClient
 

--- a/src/main/scala/org/hatdex/dex/apiV3/DexClient.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexClient.scala
@@ -10,8 +10,8 @@
 package org.hatdex.dex.apiV3
 
 import javax.inject.Inject
-import org.hatdex.dex.api.DexDataPlugs
-import org.hatdex.dex.api.DexNotices
+
+import org.hatdex.dex.api.{DexDataPlugs, DexNotices}
 import play.api.Logger
 import play.api.libs.ws.WSClient
 

--- a/src/main/scala/org/hatdex/dex/apiV3/DexOffers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexOffers.scala
@@ -1,24 +1,13 @@
 package org.hatdex.dex.apiV3
 
-import play.api.libs.json.Json
-import io.dataswift.models.dex.OfferClaimsInfo
-import play.api.libs.ws.WSResponse
-import play.api.http.Status.FORBIDDEN
-import play.api.http.Status.NOT_FOUND
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.Future
-import io.dataswift.models.dex.OfferClaimSummary
-import play.api.http.Status.BAD_REQUEST
-import play.api.http.Status.OK
-import io.dataswift.models.dex.OfferRegistration
-import play.api.libs.ws.WSRequest
-import io.dataswift.models.dex.Offer
-
-import scala.concurrent.ExecutionContext
-import play.api.libs.ws.WSClient
-import play.api.http.Status.UNAUTHORIZED
+import io.dataswift.models.dex.{Offer, OfferClaimSummary, OfferClaimsInfo, OfferRegistration}
+import org.hatdex.dex.apiV3.Errors._
 import play.api.Logger
-import play.api.http.Status.CREATED
+import play.api.http.Status.{BAD_REQUEST, CREATED, FORBIDDEN, NOT_FOUND, OK, UNAUTHORIZED}
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexOffers {
   protected val logger: Logger

--- a/src/main/scala/org/hatdex/dex/apiV3/DexOffers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexOffers.scala
@@ -1,22 +1,24 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
+package org.hatdex.dex.apiV3
 
-package org.hatdex.dex.apiV3.services
-
-import scala.concurrent.{ ExecutionContext, Future }
-
-import io.dataswift.models.dex.{ Offer, OfferClaimSummary, OfferClaimsInfo, OfferRegistration }
-import org.hatdex.dex.apiV3.services.Errors._
-import play.api.Logger
-import play.api.http.Status._
 import play.api.libs.json.Json
-import play.api.libs.ws._
+import io.dataswift.models.dex.OfferClaimsInfo
+import play.api.libs.ws.WSResponse
+import play.api.http.Status.FORBIDDEN
+import play.api.http.Status.NOT_FOUND
+
+import scala.concurrent.Future
+import io.dataswift.models.dex.OfferClaimSummary
+import play.api.http.Status.BAD_REQUEST
+import play.api.http.Status.OK
+import io.dataswift.models.dex.OfferRegistration
+import play.api.libs.ws.WSRequest
+import io.dataswift.models.dex.Offer
+
+import scala.concurrent.ExecutionContext
+import play.api.libs.ws.WSClient
+import play.api.http.Status.UNAUTHORIZED
+import play.api.Logger
+import play.api.http.Status.CREATED
 
 trait DexOffers {
   protected val logger: Logger

--- a/src/main/scala/org/hatdex/dex/apiV3/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexStats.scala
@@ -1,24 +1,19 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
+package org.hatdex.dex.apiV3
 
-package org.hatdex.dex.apiV2.services
-
-import scala.concurrent.{ ExecutionContext, Future }
-
-import io.dataswift.models.dex.NamespaceStructure
-import io.dataswift.models.dex.json.DexJsonFormats
 import io.dataswift.models.hat.DataStats
-import org.hatdex.dex.apiV2.services.Errors.{ ApiException, DataFormatException }
+import play.api.libs.json.Format
+import play.api.libs.ws.WSClient
+import play.api.libs.json.Json
+import io.dataswift.models.dex.json.DexJsonFormats
+import play.api.http.Status.OK
 import play.api.Logger
-import play.api.http.Status._
-import play.api.libs.json.{ Format, Json }
-import play.api.libs.ws._
+
+import scala.concurrent.Future
+import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSRequest
+
+import scala.concurrent.ExecutionContext
+import io.dataswift.models.dex.NamespaceStructure
 
 trait DexStats {
 
@@ -30,7 +25,6 @@ trait DexStats {
 
   implicit protected val dataStatsFormat: Format[DataStats] =
     io.dataswift.models.hat.json.DataStatsFormat.dataStatsFormat
-
   implicit protected val namespaceStructureFormat: Format[NamespaceStructure] = DexJsonFormats.namespaceStructureFormat
 
   def postStats(

--- a/src/main/scala/org/hatdex/dex/apiV3/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexStats.scala
@@ -1,19 +1,15 @@
 package org.hatdex.dex.apiV3
 
-import io.dataswift.models.hat.DataStats
-import play.api.libs.json.Format
-import play.api.libs.ws.WSClient
-import play.api.libs.json.Json
-import io.dataswift.models.dex.json.DexJsonFormats
-import play.api.http.Status.OK
-import play.api.Logger
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.Future
-import play.api.libs.ws.WSResponse
-import play.api.libs.ws.WSRequest
-
-import scala.concurrent.ExecutionContext
 import io.dataswift.models.dex.NamespaceStructure
+import io.dataswift.models.dex.json.DexJsonFormats
+import io.dataswift.models.hat.DataStats
+import org.hatdex.dex.apiV3.Errors._
+import play.api.Logger
+import play.api.http.Status.OK
+import play.api.libs.json.{Format, Json}
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexStats {
 

--- a/src/main/scala/org/hatdex/dex/apiV3/DexUsers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexUsers.scala
@@ -1,22 +1,15 @@
-/*
- * Copyright (C) 2016 HAT Data Exchange Ltd - All Rights Reserved
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
- *
- */
+package org.hatdex.dex.apiV3
 
-package org.hatdex.dex.apiV3.services
-
-import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContext, Future }
-
-import akka.Done
+import scala.concurrent.ExecutionContext
 import play.api.Logger
-import play.api.http.Status._
+import akka.Done
+import play.api.libs.ws.WSRequest
+import play.api.libs.ws.WSResponse
 import play.api.libs.json.Json
-import play.api.libs.ws._
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.Future
+import play.api.http.Status.OK
 
 trait DexUsers {
 

--- a/src/main/scala/org/hatdex/dex/apiV3/DexUsers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexUsers.scala
@@ -1,15 +1,13 @@
 package org.hatdex.dex.apiV3
 
-import scala.concurrent.ExecutionContext
-import play.api.Logger
-import akka.Done
-import play.api.libs.ws.WSRequest
-import play.api.libs.ws.WSResponse
-import play.api.libs.json.Json
-import play.api.libs.ws.WSClient
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
-import scala.concurrent.Future
+import akka.Done
+import play.api.Logger
 import play.api.http.Status.OK
+import play.api.libs.json.Json
+import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 
 trait DexUsers {
 

--- a/src/main/scala/org/hatdex/dex/apiV3/Errors.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/Errors.scala
@@ -1,4 +1,4 @@
-package org.hatdex.dex.apiV3.services
+package org.hatdex.dex.apiV3
 
 object Errors {
   class ApiException(


### PR DESCRIPTION
## Description
Remove redundant "services" packages
* now models have been moved this is the only package under each API version
* the term services is overloaded
* this nested package did not add any value and was confusing

## Source
https://dswift.atlassian.net/browse/DAS-82

## Type
- [ ] Bug Fix
- [ ] Feature Addition 
- [X] Refactor
- [ ] HotFix

## Checklist
- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
