### PR TITLE
Removing the schema configuration

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -6,4 +6,4 @@
 # Written by Andrius Aucinas <andrius.aucinas@hatdex.org>, 2 / 2017
 #
 #
-sbt.version=1.5.3
+sbt.version=1.5.5

--- a/src/it/scala/org/hatdex/dex/apiV3/DexApplicationsItTest.scala
+++ b/src/it/scala/org/hatdex/dex/apiV3/DexApplicationsItTest.scala
@@ -12,21 +12,21 @@ class DexApplicationsItTest extends AsyncFunSuite with Matchers with ScalaCheckD
   implicit val ec = scala.concurrent.ExecutionContext.global
   test("Get All Applications") {
     play.api.test.WsTestClient.withClient { ws =>
-      val client = new DexClient(ws, "localhost:9000", "http://")
+      val client = new DexClient(ws, "http://localhost:9000")
       client.applications() map { _ mustBe a [Seq[_]] }
     }
   }
 
   test("Get All Applications with filters and pagination") {
     play.api.test.WsTestClient.withClient { ws =>
-      val client = new DexClient(ws, "localhost:9000", "http://")
+      val client = new DexClient(ws, "http://localhost:9000")
       client.applications(unpublished = Some(true), kind = Some(ApplicationKind.DataPlug("Blah")), startId = None, limit = Some(5)) map { _ mustBe a [Seq[_]] }
     }
   }
 
   test("Get Application By Id") {
     play.api.test.WsTestClient.withClient { ws =>
-      val client = new DexClient(ws, "localhost:9000", "http://")
+      val client = new DexClient(ws, "http://localhost:9000")
       recoverToSucceededIf[DetailsNotFoundException] {
         client.application("Some Id") map { _ mustBe a [Seq[_]] }
       }

--- a/src/main/scala/org/hatdex/dex/api/DexClient.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexClient.scala
@@ -16,16 +16,11 @@ import javax.inject.Inject
 
 class DexClient(
     val ws: WSClient,
-    val dexAddress: String,
-    override val schema: String)
+    val dexAddress: String)
     extends DexOffers
     with DexNotices
     with DexDataPlugs
     with DexStats {
-
-  @Inject def this(
-      ws: WSClient,
-      dexAddress: String) = this(ws, dexAddress, "https://")
 
   val logger: Logger = play.api.Logger(this.getClass)
 }

--- a/src/main/scala/org/hatdex/dex/api/DexDataPlugs.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexDataPlugs.scala
@@ -10,7 +10,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 trait DexDataPlugs {
   val logger: Logger
   val ws: WSClient
-  val schema: String
   val dexAddress: String
 
   def dataplugConnectHat(
@@ -21,7 +20,7 @@ trait DexDataPlugs {
     logger.debug(s"Connect dataplug $dataplugId to $hatAddress via MarketSquare")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/dataplugs/$dataplugId/connect")
+      .url(s"$dexAddress/api/dataplugs/$dataplugId/connect")
       .withVirtualHost(dexAddress)
       .withQueryStringParameters(("hat", hatAddress))
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)

--- a/src/main/scala/org/hatdex/dex/api/DexNotices.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexNotices.scala
@@ -12,7 +12,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 trait DexNotices {
   val logger: Logger
   val ws: WSClient
-  val schema: String
   val dexAddress: String
 
   import DexJsonFormats._
@@ -24,7 +23,7 @@ trait DexNotices {
     logger.debug(s"Post notice $notice to MarketSquare")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/notices")
+      .url(s"$dexAddress/api/notices")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 

--- a/src/main/scala/org/hatdex/dex/api/DexOffers.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexOffers.scala
@@ -11,7 +11,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 trait DexOffers {
   val logger: Logger
   val ws: WSClient
-  val schema: String
   val dexAddress: String
 
   import io.dataswift.models.dex.json.DexJsonFormats._
@@ -26,7 +25,7 @@ trait DexOffers {
     logger.debug(s"Get Data Debit $offerId values from $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/offer/$offerId/claims")
+      .url(s"$dexAddress/api/offer/$offerId/claims")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 

--- a/src/main/scala/org/hatdex/dex/api/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/api/DexStats.scala
@@ -14,7 +14,6 @@ trait DexStats {
 
   val logger: Logger
   val ws: WSClient
-  val schema: String
   val dexAddress: String
 
   def postStats(
@@ -22,7 +21,7 @@ trait DexStats {
       stats: Seq[DataStats]
     )(implicit ec: ExecutionContext): Future[Unit] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/stats/report")
+      .url(s"$dexAddress/stats/report")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 

--- a/src/main/scala/org/hatdex/dex/apiV2/DexApplications.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexApplications.scala
@@ -14,7 +14,6 @@ trait DexApplications {
 
   protected val logger: Logger
   protected val ws: WSClient
-  protected val schema: String
   protected val dexAddress: String
   protected val apiVersion: String
 
@@ -27,7 +26,7 @@ trait DexApplications {
 
   def applications(includeUnpublished: Boolean = false)(implicit ec: ExecutionContext): Future[Seq[Application]] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications")
+      .url(s"$dexAddress/api/$apiVersion/applications")
       .withVirtualHost(dexAddress)
       .withQueryStringParameters("unpublished" -> includeUnpublished.toString)
       .withHttpHeaders("Accept" -> "application/json")
@@ -58,7 +57,7 @@ trait DexApplications {
     )(implicit ec: ExecutionContext): Future[Application] = {
     val requestedLanguage = lang.getOrElse("en")
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/$applicationId")
+      .url(s"$dexAddress/api/$apiVersion/applications/$applicationId")
       .withVirtualHost(dexAddress)
       .withQueryStringParameters("lang" -> requestedLanguage)
       .withHttpHeaders("Accept" -> "application/json")
@@ -91,7 +90,7 @@ trait DexApplications {
       includeUnpublished: Boolean = false
     )(implicit ec: ExecutionContext): Future[Seq[ApplicationHistory]] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications-history")
+      .url(s"$dexAddress/api/$apiVersion/applications-history")
       .withVirtualHost(dexAddress)
       .withQueryStringParameters("unpublished" -> includeUnpublished.toString)
       .withHttpHeaders("Accept" -> "application/json")
@@ -123,7 +122,7 @@ trait DexApplications {
     logger.debug(s"Register new app with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications")
+      .url(s"$dexAddress/api/$apiVersion/applications")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -161,7 +160,7 @@ trait DexApplications {
     logger.debug(s"Editing app with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/${application.id}")
+      .url(s"$dexAddress/api/$apiVersion/applications/${application.id}")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -199,7 +198,7 @@ trait DexApplications {
     logger.debug(s"Publishing app with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/${application.id}/publish")
+      .url(s"$dexAddress/api/$apiVersion/applications/${application.id}/publish")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -230,7 +229,7 @@ trait DexApplications {
     logger.debug(s"Suspending app with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/${application.id}/suspend")
+      .url(s"$dexAddress/api/$apiVersion/applications/${application.id}/suspend")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -258,7 +257,7 @@ trait DexApplications {
     logger.debug(s"Fetching application $applicationId with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/$applicationId")
+      .url(s"$dexAddress/api/$apiVersion/applications/$applicationId")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json")
 
@@ -296,7 +295,7 @@ trait DexApplications {
     logger.debug(s"Updating developer with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/developer")
+      .url(s"$dexAddress/api/$apiVersion/applications/developer")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -334,7 +333,7 @@ trait DexApplications {
     logger.debug(s"Creating new app version with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/${application.id}/versions")
+      .url(s"$dexAddress/api/$apiVersion/applications/${application.id}/versions")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 

--- a/src/main/scala/org/hatdex/dex/apiV2/DexClient.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexClient.scala
@@ -17,9 +17,7 @@ import javax.inject.Inject
 
 class DexClient(
     val ws: WSClient,
-    val dexAddress: String,
-    override val schema: String,
-    override val apiVersion: String)
+    val dexAddress: String)
     extends DexOffers
     with DexNotices
     with DexDataPlugs
@@ -27,9 +25,6 @@ class DexClient(
     with DexUsers
     with DexApplications {
 
-  @Inject def this(
-      ws: WSClient,
-      dexAddress: String) = this(ws, dexAddress, "https://", "v1.1")
-
+  override val apiVersion: String = "v2"
   val logger: Logger = play.api.Logger(this.getClass)
 }

--- a/src/main/scala/org/hatdex/dex/apiV2/DexOffers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexOffers.scala
@@ -12,7 +12,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 trait DexOffers {
   protected val logger: Logger
   protected val ws: WSClient
-  protected val schema: String
   protected val dexAddress: String
   protected val apiVersion: String
 
@@ -22,7 +21,7 @@ trait DexOffers {
     logger.debug(s"Get DEX data offers from $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/v2/offers")
+      .url(s"$dexAddress/api/v2/offers")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json")
 
@@ -53,7 +52,7 @@ trait DexOffers {
     logger.debug(s"Register new offer with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/v2/offer")
+      .url(s"$dexAddress/api/v2/offer")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -91,7 +90,7 @@ trait DexOffers {
     logger.debug(s"Get Data Debit $offerId values from $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/v2/offer/$offerId/claims")
+      .url(s"$dexAddress/api/v2/offer/$offerId/claims")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -131,7 +130,7 @@ trait DexOffers {
     logger.debug(s"Get Data Debit $offerId values from $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/v2/offer/$offerId/registerClaim")
+      .url(s"$dexAddress/api/v2/offer/$offerId/registerClaim")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
       .withQueryStringParameters(("hat", hat))
@@ -183,7 +182,7 @@ trait DexOffers {
     logger.debug(s"Get Data Debit $offerId values from $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/v2/offer/$offerId")
+      .url(s"$dexAddress/api/v2/offer/$offerId")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
       .withQueryStringParameters(("status", status))

--- a/src/main/scala/org/hatdex/dex/apiV2/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexStats.scala
@@ -15,7 +15,6 @@ trait DexStats {
 
   protected val logger: Logger
   protected val ws: WSClient
-  protected val schema: String
   protected val dexAddress: String
   protected val apiVersion: String
 
@@ -29,7 +28,7 @@ trait DexStats {
       stats: Seq[DataStats]
     )(implicit ec: ExecutionContext): Future[Unit] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/stats/report")
+      .url(s"$dexAddress/stats/report")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -47,7 +46,7 @@ trait DexStats {
 
   def availableData()(implicit ec: ExecutionContext): Future[Seq[NamespaceStructure]] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/stats/available-data")
+      .url(s"$dexAddress/stats/available-data")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json")
 

--- a/src/main/scala/org/hatdex/dex/apiV2/DexUsers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV2/DexUsers.scala
@@ -13,7 +13,6 @@ trait DexUsers {
 
   protected val logger: Logger
   protected val ws: WSClient
-  protected val schema: String
   protected val dexAddress: String
   protected val apiVersion: String
 
@@ -22,7 +21,7 @@ trait DexUsers {
       domain: String
     )(implicit ec: ExecutionContext): Future[Done] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/users/registerHat")
+      .url(s"$dexAddress/api/users/registerHat")
       .withHttpHeaders("Accept" -> "application/json")
 
     val hat = Json.obj("hatAddress" -> Json.toJson(s"$hatName.$domain"))
@@ -42,7 +41,7 @@ trait DexUsers {
       applicationId: String
     )(implicit ec: ExecutionContext): Future[Done] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/users/register-consent/$applicationId")
+      .url(s"$dexAddress/api/users/register-consent/$applicationId")
       .withVirtualHost(dexAddress)
       .withRequestTimeout(2500.millis)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> accessToken)

--- a/src/main/scala/org/hatdex/dex/apiV3/DexApplications.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexApplications.scala
@@ -28,7 +28,6 @@ trait DexApplications {
 
   protected val logger: Logger
   protected val ws: WSClient
-  protected val schema: String
   protected val dexAddress: String
   protected val apiVersion: String
 
@@ -57,7 +56,7 @@ trait DexApplications {
     )(implicit ec: ExecutionContext): Future[Seq[Application]] = {
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications")
+      .url(s"$dexAddress/api/$apiVersion/applications")
       .withVirtualHost(dexAddress)
       .withQueryStringParameters(queryParams(unpublished, kind, startId, limit): _*)
       .withHttpHeaders("Accept" -> "application/json")
@@ -88,7 +87,7 @@ trait DexApplications {
     )(implicit ec: ExecutionContext): Future[Application] = {
     val requestedLanguage = lang.getOrElse("en")
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/$applicationId")
+      .url(s"$dexAddress/api/$apiVersion/applications/$applicationId")
       .withVirtualHost(dexAddress)
       .withQueryStringParameters("lang" -> requestedLanguage)
       .withHttpHeaders("Accept" -> "application/json")
@@ -125,7 +124,7 @@ trait DexApplications {
     )(implicit ec: ExecutionContext): Future[Seq[ApplicationHistory]] = {
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications-history")
+      .url(s"$dexAddress/api/$apiVersion/applications-history")
       .withVirtualHost(dexAddress)
       .withQueryStringParameters(queryParams(unpublished, kind, startId, limit): _*)
       .withHttpHeaders("Accept" -> "application/json")
@@ -157,7 +156,7 @@ trait DexApplications {
     logger.debug(s"Register new app with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications")
+      .url(s"$dexAddress/api/$apiVersion/applications")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -195,7 +194,7 @@ trait DexApplications {
     logger.debug(s"Editing app with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/${application.id}")
+      .url(s"$dexAddress/api/$apiVersion/applications/${application.id}")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -233,7 +232,7 @@ trait DexApplications {
     logger.debug(s"Publishing app with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/${application.id}/publish")
+      .url(s"$dexAddress/api/$apiVersion/applications/${application.id}/publish")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -264,7 +263,7 @@ trait DexApplications {
     logger.debug(s"Suspending app with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/${application.id}/suspend")
+      .url(s"$dexAddress/api/$apiVersion/applications/${application.id}/suspend")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -292,7 +291,7 @@ trait DexApplications {
     logger.debug(s"Fetching application $applicationId with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/$applicationId")
+      .url(s"$dexAddress/api/$apiVersion/applications/$applicationId")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json")
 
@@ -330,7 +329,7 @@ trait DexApplications {
     logger.debug(s"Updating developer with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/developer")
+      .url(s"$dexAddress/api/$apiVersion/applications/developer")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -368,7 +367,7 @@ trait DexApplications {
     logger.debug(s"Creating new app version with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/applications/${application.id}/versions")
+      .url(s"$dexAddress/api/$apiVersion/applications/${application.id}/versions")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 

--- a/src/main/scala/org/hatdex/dex/apiV3/DexClient.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexClient.scala
@@ -17,8 +17,7 @@ import javax.inject.Inject
 
 class DexClient(
     val ws: WSClient,
-    val dexAddress: String,
-    override val schema: String)
+    val dexAddress: String)
     extends DexOffers
     with DexNotices
     with DexDataPlugs
@@ -27,9 +26,5 @@ class DexClient(
     with DexApplications {
 
   override val apiVersion: String = "v3"
-  @Inject def this(
-      ws: WSClient,
-      dexAddress: String) = this(ws, dexAddress, "https://")
-
   val logger: Logger = play.api.Logger(this.getClass)
 }

--- a/src/main/scala/org/hatdex/dex/apiV3/DexOffers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexOffers.scala
@@ -12,7 +12,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 trait DexOffers {
   protected val logger: Logger
   protected val ws: WSClient
-  protected val schema: String
   protected val dexAddress: String
   protected val apiVersion: String
 
@@ -22,7 +21,7 @@ trait DexOffers {
     logger.debug(s"Get DEX data offers from $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/offers")
+      .url(s"$dexAddress/api/$apiVersion/offers")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json")
 
@@ -53,7 +52,7 @@ trait DexOffers {
     logger.debug(s"Register new offer with $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/offer")
+      .url(s"$dexAddress/api/$apiVersion/offer")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -91,7 +90,7 @@ trait DexOffers {
     logger.debug(s"Get Data Debit $offerId values from $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/offer/$offerId/claims")
+      .url(s"$dexAddress/api/$apiVersion/offer/$offerId/claims")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -131,7 +130,7 @@ trait DexOffers {
     logger.debug(s"Get Data Debit $offerId values from $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/offer/$offerId/registerClaim")
+      .url(s"$dexAddress/api/$apiVersion/offer/$offerId/registerClaim")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
       .withQueryStringParameters(("hat", hat))
@@ -183,7 +182,7 @@ trait DexOffers {
     logger.debug(s"Get Data Debit $offerId values from $dexAddress")
 
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/offer/$offerId")
+      .url(s"$dexAddress/api/$apiVersion/offer/$offerId")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
       .withQueryStringParameters(("status", status))

--- a/src/main/scala/org/hatdex/dex/apiV3/DexStats.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexStats.scala
@@ -15,7 +15,6 @@ trait DexStats {
 
   protected val logger: Logger
   protected val ws: WSClient
-  protected val schema: String
   protected val dexAddress: String
   protected val apiVersion: String
 
@@ -28,7 +27,7 @@ trait DexStats {
       stats: Seq[DataStats]
     )(implicit ec: ExecutionContext): Future[Unit] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/stats/report")
+      .url(s"$dexAddress/stats/report")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> access_token)
 
@@ -46,7 +45,7 @@ trait DexStats {
 
   def availableData()(implicit ec: ExecutionContext): Future[Seq[NamespaceStructure]] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/stats/available-data")
+      .url(s"$dexAddress/stats/available-data")
       .withVirtualHost(dexAddress)
       .withHttpHeaders("Accept" -> "application/json")
 

--- a/src/main/scala/org/hatdex/dex/apiV3/DexUsers.scala
+++ b/src/main/scala/org/hatdex/dex/apiV3/DexUsers.scala
@@ -13,7 +13,6 @@ trait DexUsers {
 
   protected val logger: Logger
   protected val ws: WSClient
-  protected val schema: String
   protected val dexAddress: String
   protected val apiVersion: String
 
@@ -22,7 +21,7 @@ trait DexUsers {
       domain: String
     )(implicit ec: ExecutionContext): Future[Done] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/users/registerHat")
+      .url(s"$dexAddress/api/$apiVersion/users/registerHat")
       .withHttpHeaders("Accept" -> "application/json")
 
     val hat = Json.obj("hatAddress" -> Json.toJson(s"$hatName.$domain"))
@@ -42,7 +41,7 @@ trait DexUsers {
       applicationId: String
     )(implicit ec: ExecutionContext): Future[Done] = {
     val request: WSRequest = ws
-      .url(s"$schema$dexAddress/api/$apiVersion/users/register-consent/$applicationId")
+      .url(s"$dexAddress/api/$apiVersion/users/register-consent/$applicationId")
       .withVirtualHost(dexAddress)
       .withRequestTimeout(2500.millis)
       .withHttpHeaders("Accept" -> "application/json", "X-Auth-Token" -> accessToken)


### PR DESCRIPTION
## Description
Removing the schema configuration from the dex client. This is required for the new domain structure and to also align it with the rest of our services where the schema is part of the URL for each service. 

## Type
- [ ] Bug Fix
- [ ] Feature Addition 
- [X] Refactor
- [ ] HotFix

## Checklist
- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
